### PR TITLE
Fix issue getting selection for queries with '__typename'.

### DIFF
--- a/src/getSelection.test.ts
+++ b/src/getSelection.test.ts
@@ -19,6 +19,20 @@ describe('getSelection', () => {
     expect(selection).toEqual(['firstName', 'lastName']);
   });
 
+  it('can parse a selection with __typename', async () => {
+    const { info } = await resolve(gql`
+      query {
+        testQuery {
+          __typename
+          firstName
+        }
+      }
+    `);
+
+    const selection = getSelection(info);
+    expect(selection).toEqual(['firstName']);
+  });
+
   it('can parse a selection with named fragment', async () => {
     const { info } = await resolve(gql`
       query {

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -29,13 +29,17 @@ export const getSelection = (info: GraphQLResolveInfo): string[] => {
     parseNode(selection, info),
   );
 
-  // Iterate over our selection, and see if any of the selected
-  // fields are marked with `@requires` in the schema:
   const allFields = info.returnType.getFields();
   return flatMap(selection, name => {
     const field = allFields[name];
 
-    return field && field.astNode ? parseRequiredFields(field.astNode) : [];
+    // If the field doesn't exist in the schema, exclude it:
+    if (!field || !field.astNode) {
+      return [];
+    }
+
+    // Return the field & any others mentioned by `@requires`:
+    return parseRequiredFields(field.astNode);
   });
 };
 

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -32,17 +32,17 @@ export const getSelection = (info: GraphQLResolveInfo): string[] => {
   // Iterate over our selection, and see if any of the selected
   // fields are marked with `@requires` in the schema:
   const allFields = info.returnType.getFields();
-  return flatMap(selection, field => {
-    const { astNode } = allFields[field];
+  return flatMap(selection, name => {
+    const field = allFields[name];
 
-    return astNode ? parseRequiresDirective(astNode) : field;
+    return field && field.astNode ? parseRequiredFields(field.astNode) : [];
   });
 };
 
 /**
  * Parse `@requires` directives for the given node.
  */
-const parseRequiresDirective = (node: FieldDefinitionNode): string[] => {
+const parseRequiredFields = (node: FieldDefinitionNode): string[] => {
   const directives = node.directives || [];
   const requiresDirective = directives.find(
     directive => directive.name.value === 'requires',


### PR DESCRIPTION
### What's this PR do?
This pull request fixes a bug querying fields with `__typename`, since that doesn't exist as a "node" in the schema and so `allFields[field]` would be undefined. Since this isn't a real field, it is excluded from the result of `getSelection`.

### How should this be reviewed?
I've added a failing test demonstrating the bug I ran into in dfef443. You can see the following change & refactor commits both pass this test! 😌

### Checklist
- [x] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
