### PR TITLE
Fix issue parsing selection on list return type.

### DIFF
--- a/src/getSelection.test.ts
+++ b/src/getSelection.test.ts
@@ -83,6 +83,20 @@ describe('getSelection', () => {
     expect(selection).toEqual(['firstName', 'age', 'birthdate']);
   });
 
+  it('can parse a selection from a list return type', async () => {
+    const { info } = await resolve(gql`
+      query {
+        listQuery {
+          firstName
+          lastName
+        }
+      }
+    `);
+
+    const selection = getSelection(info);
+    expect(selection).toEqual(['firstName', 'lastName']);
+  });
+
   it.todo('can parse a selection using @include(false) in query');
   it.todo('can parse a selection using @include(true) in query');
   it.todo('can parse a selection using @skip(false) in query');
@@ -113,6 +127,7 @@ const resolve = (query: string): Promise<ResolverArguments> => {
 
     type Query {
       testQuery: User
+      listQuery: [User]
     }
   `;
 
@@ -124,6 +139,10 @@ const resolve = (query: string): Promise<ResolverArguments> => {
       resolvers: {
         Query: {
           testQuery: (root, args, context, info) => {
+            resolve({ root, args, context, info });
+            return null;
+          },
+          listQuery: (root, args, context, info) => {
             resolve({ root, args, context, info });
             return null;
           },


### PR DESCRIPTION
### What's this PR do?
This pull request fixes an issue where `getSelection` would not be able to load the schema properly when reading a list return type (e.g. `[User]` instead of `User`). With this change, we now properly parse the type of element _in_ the list & read its fields from the schema.

### How should this be reviewed?
I added a failing test in 533f69d and fixed the issue in 4297816.

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
