### PR TITLE
Add ability to get the fields at a given "path" in the query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ userLoader.load(2, ['first_name']);
 ```
 
 This is especially handy for
-[GraphQL resolvers](https://graphql.org/learn/execution)! Use it with the included [`getSelection` helper](#getselectioninfo) to load only the specific fields that were requested in the given GraphQL query from your database or backend. For
-example:
+[GraphQL resolvers](https://graphql.org/learn/execution)! Use it with the
+included [`getSelection` helper](#getselectioninfo) to load only the specific
+fields that were requested in the given GraphQL query from your database or
+backend. For example:
 
 ```js
 import { FieldDataLoader, getSelection } from 'fielddataloader';
@@ -78,9 +80,15 @@ Clears the entire cache. To be used when some event results in unknown
 invalidations across this particular `FieldDataLoader`. Returns itself for
 method chaining.
 
-##### `getSelection(info)`
+##### `getFields(info, [returnType], [path])`
 
-Given the `info` argument from a [GraphQL resolver](https://graphql.org/learn/execution/#root-fields-resolvers), returns an array containing the names of any requested fields. Supports named & inline fragments, and fields referenced by Apollo Federation's [`@requires` directive](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#requires).
+Given the `info` argument from a
+[GraphQL resolver](https://graphql.org/learn/execution/#root-fields-resolvers),
+returns an array containing the names of any requested fields. Supports named &
+inline fragments, and fields referenced by Apollo Federation's
+[`@requires` directive](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#requires).
+You can optionally pass a `returnType` and `path` if reading fields nested
+within a query (rather than at the root).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,6 +543,12 @@
       "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
       "dev": true
     },
+    "@types/node": {
+      "version": "12.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5062,9 +5062,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "prettier-check": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@dosomething/eslint-config": "^5.0.1",
     "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.138",
+    "@types/node": "^12.11.7",
     "eslint": "^4.19.1",
     "graphql": "^14.5.6",
     "graphql-tools": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "graphql": "^14.5.6",
     "graphql-tools": "^4.0.5",
     "jest": "^24.9.0",
-    "prettier": "1.8.2",
+    "prettier": "1.18.2",
     "prettier-check": "^2.0.0",
     "tagged-template-noop": "^2.1.0",
     "ts-jest": "^24.1.0",

--- a/src/getSelection.test.ts
+++ b/src/getSelection.test.ts
@@ -2,9 +2,9 @@ import gql from 'tagged-template-noop';
 import { makeExecutableSchema } from 'graphql-tools';
 import { graphql, GraphQLResolveInfo } from 'graphql';
 
-import { parseNode, getSelection } from './getSelection';
+import { getSelection, getFields } from './getSelection';
 
-describe('parseNode', () => {
+describe('getSelection', () => {
   it('can parse a simple selection', async () => {
     const { info } = await resolve(gql`
       query {
@@ -17,7 +17,7 @@ describe('parseNode', () => {
       }
     `);
 
-    const selection = parseNode(info.fieldNodes[0], info);
+    const selection = getSelection(info.fieldNodes[0], info);
     expect(selection).toHaveProperty('firstName');
     expect(selection).toHaveProperty('lastName');
   });
@@ -36,7 +36,7 @@ describe('parseNode', () => {
       }
     `);
 
-    const selection = parseNode(info.fieldNodes[0], info);
+    const selection = getSelection(info.fieldNodes[0], info);
     expect(selection).toHaveProperty('edges.node');
     expect(selection).toHaveProperty('edges.node.firstName');
     expect(selection).toHaveProperty('edges.node.lastName');
@@ -57,14 +57,14 @@ describe('parseNode', () => {
       }
     `);
 
-    const selection = parseNode(info.fieldNodes[0], info);
+    const selection = getSelection(info.fieldNodes[0], info);
     expect(selection).toHaveProperty('firstName');
     expect(selection).toHaveProperty('lastName');
     expect(selection).toHaveProperty('email');
   });
 });
 
-describe('getSelection', () => {
+describe('getFields', () => {
   it('can parse a simple selection', async () => {
     const { info } = await resolve(gql`
       query {
@@ -75,7 +75,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName', 'lastName']);
   });
 
@@ -89,7 +89,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName']);
   });
 
@@ -108,7 +108,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName', 'lastName', 'email']);
   });
 
@@ -125,7 +125,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName', 'lastName', 'email']);
   });
 
@@ -139,7 +139,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName', 'age', 'birthdate']);
   });
 
@@ -153,7 +153,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info);
+    const selection = getFields(info);
     expect(selection).toEqual(['firstName', 'lastName']);
   });
 
@@ -171,7 +171,7 @@ describe('getSelection', () => {
       }
     `);
 
-    const selection = getSelection(info, 'User', 'edges.node');
+    const selection = getFields(info, 'User', 'edges.node');
     expect(selection).toEqual(['firstName', 'lastName']);
   });
 

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -16,7 +16,7 @@ import {
   isListType,
 } from 'graphql';
 
-type RecursiveDictionary<T> = T|{[x: string]: RecursiveDictionary<T>};
+type RecursiveDictionary<T> = T | { [x: string]: RecursiveDictionary<T> };
 
 /**
  * Get a list of fields requested in the given query, including any
@@ -45,7 +45,7 @@ export const getFields = (
 
   // We'll then get the given path, if we're scoping to a subset,
   // and read the keys at that level of the query tree:
-  const subset = path ? get(set, path) : set; 
+  const subset = path ? get(set, path) : set;
   const selection = Object.keys(subset);
 
   return flatMap(selection, name => {
@@ -105,7 +105,6 @@ const flattenSelectionSet = (
 
     return node;
   });
-
 };
 
 /**
@@ -116,12 +115,12 @@ export const getSelection = (
   node: FieldNode,
   info: GraphQLResolveInfo,
 ): RecursiveDictionary<FieldNode> => {
-  if (! node.selectionSet) {
+  if (!node.selectionSet) {
     return node;
   }
 
   const flattenedSet = flattenSelectionSet(node.selectionSet, info);
-  const keyedSet = keyBy(flattenedSet, 'name.value')
+  const keyedSet = keyBy(flattenedSet, 'name.value');
 
   return mapValues(keyedSet, n => getSelection(n, info));
 };

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -20,7 +20,7 @@ import {
  * Get a list of fields requested in the given query, including any
  * additional field dependencies indicated by `@required` in the schema.
  */
-export const getSelection = (
+export const getFields = (
   info: GraphQLResolveInfo,
   returnType?: string,
   path?: string,
@@ -39,7 +39,7 @@ export const getSelection = (
   }
 
   // Parse any fragments into an easily traversable tree:
-  const set = parseNode(info.fieldNodes[0], info);
+  const set = getSelection(info.fieldNodes[0], info);
 
   // We'll then get the given path, if we're scoping to a subset,
   // and read the keys at that level of the query tree:
@@ -111,10 +111,8 @@ type RecursiveDictionary<T> = T|{[x: string]: RecursiveDictionary<T>};
 /**
  * Recursively parse nodes & any fragments into a
  * dictionary-like structure for easy traversal.
- * 
- * @TODO: Rename to 'getSelection'.
  */
-export const parseNode = (
+export const getSelection = (
   node: FieldNode,
   info: GraphQLResolveInfo,
 ): RecursiveDictionary<FieldNode> => {
@@ -125,7 +123,7 @@ export const parseNode = (
   const flattenedSet = flattenSelectionSet(node.selectionSet, info);
   const keyedSet = keyBy(flattenedSet, 'name.value')
 
-  return mapValues(keyedSet, n => parseNode(n, info));
+  return mapValues(keyedSet, n => getSelection(n, info));
 };
 
 /**

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -1,4 +1,4 @@
-import { flatMap, isNil } from 'lodash';
+import { get, isNil, flatMap, keyBy, mapValues } from 'lodash';
 
 import Maybe from 'graphql/tsutils/Maybe';
 import {
@@ -6,6 +6,8 @@ import {
   FragmentSpreadNode,
   InlineFragmentNode,
   SelectionNode,
+  FieldNode,
+  SelectionSetNode,
   GraphQLOutputType,
   GraphQLObjectType,
   GraphQLInterfaceType,
@@ -18,27 +20,34 @@ import {
  * Get a list of fields requested in the given query, including any
  * additional field dependencies indicated by `@required` in the schema.
  */
-export const getSelection = (info: GraphQLResolveInfo): string[] => {
-  var set = info.fieldNodes[0].selectionSet;
-  const typeName = isListType(info.returnType)
+export const getSelection = (
+  info: GraphQLResolveInfo,
+  returnType?: string,
+  path?: string,
+): string[] => {
+  // For simple queries, we can infer return type. If using a 'path', it
+  // must be provided explicitly by the 'returnType' parameter:
+  const inferredType = isListType(info.returnType)
     ? info.returnType.ofType
     : info.returnType.name;
+  const type = info.schema.getType(returnType || inferredType);
 
-  const returnType = info.schema.getType(typeName);
-
-  // If there's no fields on the selection or return type, there's
-  // no point in doing any futher looking:
-  if (!set || !set.selections || !hasFields(returnType)) {
+  // If there's no fields on the selection or return type, then
+  // there's no point in wasting time by delving futher:
+  if (!info.fieldNodes[0] || !hasFields(type)) {
     return [];
   }
 
-  const selection = flatMap(set.selections, selection =>
-    parseNode(selection, info),
-  );
+  // Parse any fragments into an easily traversable tree:
+  const set = parseNode(info.fieldNodes[0], info);
 
-  const allFields = returnType.getFields();
+  // We'll then get the given path, if we're scoping to a subset,
+  // and read the keys at that level of the query tree:
+  const subset = path ? get(set, path) : set; 
+  const selection = Object.keys(subset);
+
   return flatMap(selection, name => {
-    const field = allFields[name];
+    const field = type.getFields()[name];
 
     // If the field doesn't exist in the schema, exclude it:
     if (!field || !field.astNode) {
@@ -74,20 +83,49 @@ const parseRequiredFields = (node: FieldDefinitionNode): string[] => {
 };
 
 /**
- * Parse the name of this field node & any fragments.
+ * Given a selection set, resolve any fragments and inline them
+ * in a single "flattened" selection.
  */
-const parseNode = (node: SelectionNode, info: GraphQLResolveInfo): string[] => {
-  if (isFragmentSpread(node)) {
-    const { selections } = info.fragments[node.name.value].selectionSet;
-    return flatMap(selections, selection => parseNode(selection, info));
+const flattenSelectionSet = (
+  node: SelectionSetNode,
+  info: GraphQLResolveInfo,
+): readonly FieldNode[] => {
+  return flatMap(node.selections, node => {
+    if (isFragmentSpread(node)) {
+      const { selectionSet } = info.fragments[node.name.value];
+      return flattenSelectionSet(selectionSet, info);
+    }
+
+    if (isInlineFragment(node)) {
+      const { selectionSet } = node;
+      return flattenSelectionSet(selectionSet, info);
+    }
+
+    return node;
+  });
+
+};
+
+type RecursiveDictionary<T> = T|{[x: string]: RecursiveDictionary<T>};
+
+/**
+ * Recursively parse nodes & any fragments into a
+ * dictionary-like structure for easy traversal.
+ * 
+ * @TODO: Rename to 'getSelection'.
+ */
+export const parseNode = (
+  node: FieldNode,
+  info: GraphQLResolveInfo,
+): RecursiveDictionary<FieldNode> => {
+  if (! node.selectionSet) {
+    return node;
   }
 
-  if (isInlineFragment(node)) {
-    const { selections } = node.selectionSet;
-    return flatMap(selections, selection => parseNode(selection, info));
-  }
+  const flattenedSet = flattenSelectionSet(node.selectionSet, info);
+  const keyedSet = keyBy(flattenedSet, 'name.value')
 
-  return [node.name.value];
+  return mapValues(keyedSet, n => parseNode(n, info));
 };
 
 /**
@@ -98,7 +136,7 @@ const isFragmentSpread = (
 ): selection is FragmentSpreadNode =>
   (selection as FragmentSpreadNode).kind == 'FragmentSpread';
 
-/**
+/*
  * Is this an InlineFragment node?
  */
 const isInlineFragment = (
@@ -107,7 +145,7 @@ const isInlineFragment = (
   (selection as InlineFragmentNode).kind === 'InlineFragment';
 
 /**
- * Does the given node have fields (e.g. not a scalar, enum, etc)?
+ * Does the given type have fields (e.g. not a scalar, enum, etc)?
  */
 const hasFields = (
   type: GraphQLOutputType | GraphQLNamedType | Maybe<GraphQLNamedType>,

--- a/src/getSelection.ts
+++ b/src/getSelection.ts
@@ -16,6 +16,8 @@ import {
   isListType,
 } from 'graphql';
 
+type RecursiveDictionary<T> = T|{[x: string]: RecursiveDictionary<T>};
+
 /**
  * Get a list of fields requested in the given query, including any
  * additional field dependencies indicated by `@required` in the schema.
@@ -105,8 +107,6 @@ const flattenSelectionSet = (
   });
 
 };
-
-type RecursiveDictionary<T> = T|{[x: string]: RecursiveDictionary<T>};
 
 /**
  * Recursively parse nodes & any fragments into a

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 // FieldDataLoader and it's associated types:
 export { FieldDataLoader, Response, Key, BatchLoadFn } from './FieldDataLoader';
 
-// The `getSelection` helper for parsing requested fields:
-export { getSelection } from './getSelection';
+// The `getSelection` helper gives a simplified AST for the query, with fragments
+// resolved and flattened, and `getFields` gives the fields at a given path in the
+// query (including implicitly required fields from '@required').
+export { getSelection, getFields } from './getSelection';


### PR DESCRIPTION
### What's this PR do?
This pull request adds the ability to (optionally) specify a path in the query to get fields from. This is helpful when the resolver is not directly returning the "thing" it's querying, like in [Relay Cursor Connections](https://facebook.github.io/relay/graphql/connections.htm) (which I'm prototyping in DoSomething/graphql#142):

```js
const { info } = await resolve(gql`
  query {
    relayQuery {
      edges {
        node { # <----- this is the User that's queried by 'relayQuery'
          firstName
          lastName
        }
      }
    }
  }
`);

const selection = getFields(info, 'User', 'edges.node');
expect(selection).toEqual(['firstName', 'lastName']);
```

### How should this be reviewed?
Sorry, this required more refactoring than I'd anticipated!

I ended up creating a new `parseNode` helper that is responsible for resolving fragments & turning it into a simplified tree, and then using that to simplify our `getSelection` helper and make it easy to read from different parts of the "tree" via Lodash's `get`. d9ac279

I then renamed `parseNode` to `getSelection`, and our existing `getSelection` to `getFields` (since technically I think the selection includes all the nested stuff as well, and "parse node" was a pretty lame name for a function). 44f8091

Finally, I updated Prettier since the version we were on [didn't support the `readonly` operator](https://git.io/JeuFp).

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
